### PR TITLE
enabled proguard

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -19,7 +19,8 @@ android {
 
     buildTypes {
         release {
-            minifyEnabled false
+            minifyEnabled true
+            shrinkResources true
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
         }
     }


### PR DESCRIPTION
- Enabled proguard
- Shrinking unused classes, functions
- Application size: https://drive.google.com/file/d/1sGqMU4e8w1APqm9j3BLz84IUxBX6DguG/view?usp=sharing
- APK: https://drive.google.com/file/d/1_o_fGGX0VleJOPajtrYjRx03mLneJ3wG/view?usp=sharing
- Mapped files: https://drive.google.com/drive/folders/1LmmJFJoEpOBp9z1V78OGTrbej_HA73Xz?usp=sharing
- APK size difference:
- When proguard disabled -> APK Size: 4 MB, Download size: 3.3 MB
- When proguard enabled -> APK Size: 1.6 MB, Download size: 972.5 KB